### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/appinsights.tf
+++ b/appinsights.tf
@@ -1,15 +1,16 @@
-resource "azurerm_application_insights" "appinsights" {
-  name                = join("-", [var.product, var.env])
-  location            = var.appinsights_location
-  resource_group_name = azurerm_resource_group.rg.name
-  application_type    = var.application_type
-  tags                = local.tags
+module "application_insights" {
+  source   = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+  location = var.appinsights_location
+  env      = var.env
+  product  = var.product
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+
+  resource_group_name = azurerm_resource_group.rg.name
+
+  common_tags = local.tags
+}
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }

--- a/key-vault.tf
+++ b/key-vault.tf
@@ -1,26 +1,26 @@
 module "vault" {
-  source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  name                    = join("-", [var.product, var.env])
-  product                 = join("-", [var.product, "shared"])
-  env                     = var.env
-  tenant_id               = var.tenant_id
-  object_id               = var.jenkins_AAD_objectId
-  resource_group_name     = azurerm_resource_group.rg.name
-  product_group_object_id = var.product_group_object_id
-  create_managed_identity = true
-  common_tags             = local.tags
+  source                               = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
+  name                                 = join("-", [var.product, var.env])
+  product                              = join("-", [var.product, "shared"])
+  env                                  = var.env
+  tenant_id                            = var.tenant_id
+  object_id                            = var.jenkins_AAD_objectId
+  resource_group_name                  = azurerm_resource_group.rg.name
+  product_group_object_id              = var.product_group_object_id
+  create_managed_identity              = true
+  common_tags                          = local.tags
   additional_managed_identities_access = var.additional_managed_identities_access
 }
 
 resource "azurerm_key_vault_secret" "appInsightsInstrumentationKey" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.vault.key_vault_id
 }
 
 resource "azurerm_key_vault_secret" "app_insights_connection_string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.vault.key_vault_id
 }
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.